### PR TITLE
modify function getEncodedEntryUri(bucket, key)

### DIFF
--- a/qiniu/rs.js
+++ b/qiniu/rs.js
@@ -137,7 +137,7 @@ function fileHandle(op, entries, onret) {
 }
 
 function getEncodedEntryUri(bucket, key) {
-  return util.urlsafeBase64Encode(bucket + ':' + key);
+  return util.urlsafeBase64Encode(bucket + (key ? ':' + key : ''));
 }
 
 // ----- token --------


### PR DESCRIPTION
you can also use the <bucket> instead of <bucket>:<key> when fetching