### PR TITLE
fix Cannot read property 'error' of null

### DIFF
--- a/qiniu/rpc.js
+++ b/qiniu/rpc.js
@@ -52,7 +52,7 @@ function post(uri, form, headers, onresp) {
   var req = urllib.request(uri, data, function(err, result, res) {
     var rerr = null;
     if (err || Math.floor(res.statusCode/100) !== 2) {
-      rerr = {code: res&&res.statusCode||-1, error: err||result.error||''};
+      rerr = {code: res&&res.statusCode||-1, error: err||result&&result.error||''};
     }
     onresp(rerr, result, res);
   });


### PR DESCRIPTION
```
      rerr = {code: res&&res.statusCode||-1, error: err||result.error||''};
                                                               ^
TypeError: Cannot read property 'error' of null
    at /Users/loulin/qiniu/node_modules/qiniu/qiniu/rpc.js:55:64
    at done (/Users/loulin/qiniu/node_modules/qiniu/node_modules/urllib/lib/urllib.js:193:5)
    at IncomingMessage.<anonymous> (/Users/loulin/qiniu/node_modules/qiniu/node_modules/urllib/lib/urllib.js:304:7)
    at IncomingMessage.emit (events.js:129:20)
    at _stream_readable.js:908:16
    at process._tickCallback (node.js:355:11)
```