### PR TITLE
fix Unhandled stream error in pipe

### DIFF
--- a/qiniu/io.js
+++ b/qiniu/io.js
@@ -50,7 +50,7 @@ function putReadable (uptoken, key, rs, extra, onret) {
   
   var form = getMultipart(uptoken, key, rs, extra);
 
-  rpc.postMultipart(conf.UP_HOST, form, onret);
+  return rpc.postMultipart(conf.UP_HOST, form, onret);
 }
 
 function put(uptoken, key, body, extra, onret) {
@@ -65,11 +65,11 @@ function put(uptoken, key, body, extra, onret) {
     var bodyCrc32 = getCrc32(body);
     extra.crc32 = '' + parseInt(bodyCrc32, 16);
   }
-  putReadable(uptoken, key, rs, extra, onret)
+  return putReadable(uptoken, key, rs, extra, onret)
 }
 
 function putWithoutKey(uptoken, body, extra, onret) {
-  put(uptoken, null, body, extra, onret);
+  return put(uptoken, null, body, extra, onret);
 }
 
 function getMultipart(uptoken, key, rs, extra) {
@@ -104,9 +104,9 @@ function putFile(uptoken, key, loadFile, extra, onret) {
     extra.mimeType = mime.lookup(loadFile);
   }
 
-  putReadable(uptoken, key, rs, extra, onret);
+  return putReadable(uptoken, key, rs, extra, onret);
 }
 
 function putFileWithoutKey(uptoken, loadFile, extra, onret) {
-  putFile(uptoken, null, loadFile, extra, onret);
+  return putFile(uptoken, null, loadFile, extra, onret);
 }

--- a/qiniu/rpc.js
+++ b/qiniu/rpc.js
@@ -7,7 +7,7 @@ exports.postWithForm = postWithForm;
 exports.postWithoutForm = postWithoutForm;
 
 function postMultipart(uri, form, onret) {
-  post(uri, form, form.headers(), onret);
+  return post(uri, form, form.headers(), onret);
 }
 
 function postWithForm(uri, form, token, onret) {
@@ -17,7 +17,7 @@ function postWithForm(uri, form, token, onret) {
   if (token) {
     headers['Authorization'] = token;
   }
-  post(uri, form, headers, onret);
+  return post(uri, form, headers, onret);
 }
 
 function postWithoutForm(uri, token, onret) {
@@ -27,7 +27,7 @@ function postWithoutForm(uri, token, onret) {
   if (token) {
     headers['Authorization'] = token;
   }
-  post(uri, null, headers, onret);
+  return post(uri, null, headers, onret);
 }
 
 function post(uri, form, headers, onresp) {
@@ -56,5 +56,7 @@ function post(uri, form, headers, onresp) {
     }
     onresp(rerr, result, res);
   });
+
+  return req;
 }
 


### PR DESCRIPTION
如果不监听请求stream error，当发生客户端网络错误时，node进程会完全崩溃。

Request stream可以对error事件不做任何事情，但是必须监听，否则在某个tick周期就挂掉了。

本次修复并没有直接监听req stream的error事件，而是将stream返回给调用方，由开发者自己处理，因为这种error也会同时出现在response callback。

多次测试可能的错误如下：
```
stream.js:94
      throw er; // Unhandled stream error in pipe.
            ^
Error: getaddrinfo ENOTFOUND upload
    at errnoException (dns.js:44:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:94:26)
```

```
stream.js:94
      throw er; // Unhandled stream error in pipe.
            ^
Error: connect ECONNREFUSED
    at exports._errnoException (util.js:746:11)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1012:19)
```