### PR TITLE
querystring.escape to encodeURI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-node_js:
-- "0.1"
-- "5"
+- "0.10"
+- "4"
+- "6"
 before_script:
 - export QINIU_ACCESS_KEY=QWYn5TFQsLLU1pL5MFEmX3s5DmHdUThav9WyOWOm
 - export QINIU_SECRET_KEY=Bxckh6FA-Fbs9Yt3i3cbKVK22UPBmAOHJcL95pGz

--- a/qiniu/rs.js
+++ b/qiniu/rs.js
@@ -1,7 +1,6 @@
 var url = require('url');
 var crypto = require('crypto');
 var formstream = require('formstream');
-var querystring = require('querystring');
 var rpc = require('./rpc');
 var conf = require('./conf');
 var util = require('./util');
@@ -330,5 +329,5 @@ GetPolicy.prototype.makeRequest = function(baseUrl, mac) {
 // query like '-thumbnail', '?imageMogr2/thumbnail/960x' and so on
 function makeBaseUrl(domain, key, query) {
   key = new Buffer(key);
-  return (/^https?:\/\//.test(domain) ? domain : 'http://' + domain) + '/' + querystring.escape(key) + (query || '');
+  return (/^https?:\/\//.test(domain) ? domain : 'http://' + domain) + '/' + encodeURI(key) + (query || '');
 }


### PR DESCRIPTION
```
querystring.escape('/test/hello world.png')  // => '%2Ftest%2Fhello%20world.png'
encodeURI('/test/hello world.png')           // => '/test/hello%20world.png'
```