### PR TITLE
Add feature: zone.js using aysnc http request api to fetch zone

### DIFF
--- a/qiniu/io.js
+++ b/qiniu/io.js
@@ -50,11 +50,14 @@ function putReadable (uptoken, key, rs, extra, onret) {
       onret({code: -1, error: err.toString()}, {});
   });
 
-  var form = getMultipart(uptoken, key, rs, extra);
-  // 设置上传域名
-  zone.up_host(uptoken, conf);
 
-  return rpc.postMultipart(conf.UP_HOST, form, onret);
+  // 设置上传域名
+  // zone.up_host(uptoken, conf);
+  zone.up_host_async(uptoken, conf, function() {
+      var form = getMultipart(uptoken, key, rs, extra);
+      return rpc.postMultipart(conf.UP_HOST, form, onret);
+  });
+
 }
 
 

--- a/qiniu/rpc.js
+++ b/qiniu/rpc.js
@@ -34,13 +34,13 @@ function post(uri, form, headers, onresp) {
   headers = headers || {};
   headers['User-Agent'] = headers['User-Agent'] || conf.USER_AGENT;
 
+
   var data = {
     headers: headers,
     method: 'POST',
     dataType: 'json',
     timeout: conf.RPC_TIMEOUT,
   };
-
   if (Buffer.isBuffer(form) || typeof form === 'string') {
     data.content = form;
   } else if (form) {
@@ -59,4 +59,3 @@ function post(uri, form, headers, onresp) {
 
   return req;
 }
-

--- a/qiniu/zone.js
+++ b/qiniu/zone.js
@@ -1,5 +1,6 @@
-var request = require('sync-request');
-
+// var request = require('urllib-sync').request;
+var urllib = require('urllib');
+var util = require('./util');
 //conf 为全局变量
 exports.up_host = function (uptoken, conf){
 
@@ -27,18 +28,20 @@ exports.up_host = function (uptoken, conf){
     if((new Date().getTime() < conf.EXPIRE) && bucket == conf.BUCKET){
         return;
     }
-    
+
     //记录bucket名
     conf.BUCKET = bucket;
 
-    var res = request('GET', 'http://uc.qbox.me/v1/query?ak=' + ak + '&bucket=' + bucket, {
+    var request_url = 'http://uc.qbox.me/v1/query?ak='+ ak + '&bucket=' + bucket;
+
+    var res = request('http://uc.qbox.me/v1/query?ak='+ ak + '&bucket=' + bucket, {
       'headers': {
         'Content-Type': 'application/json'
       }
     });
 
     if(res.statusCode == 200){
-        
+
         var json_str = JSON.parse(res.body.toString());
 
         //判断设置使用的协议, 默认使用http
@@ -48,7 +51,7 @@ exports.up_host = function (uptoken, conf){
             conf.UP_HOST = json_str.https.up[0];
         }
 
-        conf.EXPIRE = 86400 + new Date().getTime(); 
+        conf.EXPIRE = 86400 + new Date().getTime();
 
     }else{
         var err = new Error('Server responded with status code ' + res.statusCode + ':\n' + res.body.toString());
@@ -57,5 +60,78 @@ exports.up_host = function (uptoken, conf){
         err.body = res.body;
         throw err;
     }
+
+
+
+}
+
+
+
+exports.up_host_async = function (uptoken, conf, callback){
+
+    var version = process.versions;
+    var num = version.node.split(".")[0];
+
+    // node 版本号低于 1.0.0, 使用默认域名上传，可以在conf中指定上传域名
+    if(num < 1 ){
+        conf.AUTOZONE = false;
+    }
+
+    if(!conf.AUTOZONE){
+        callback();
+        return;
+    }
+
+    var ak = uptoken.toString().split(":")[0];
+    var tokenPolicy = uptoken.toString().split(":")[2];
+    var tokenPolicyStr = new Buffer(tokenPolicy, 'base64').toString();
+    var json_tokenPolicyStr = JSON.parse(tokenPolicyStr);
+
+    var scope = json_tokenPolicyStr.scope;
+    var bucket = scope.toString().split(":")[0];
+
+    // bucket 相同，上传域名仍在过期时间内
+    if((new Date().getTime() < conf.EXPIRE) && bucket == conf.BUCKET){
+        callback();
+        return;
+    }
+
+    //记录bucket名
+    conf.BUCKET = bucket;
+    var request_url = 'http://uc.qbox.me/v1/query?ak='+ ak + '&bucket=' + bucket;
+    var data = {
+      contentType: 'application/json',
+      method: 'GET',
+    };
+
+
+    var req = urllib.request(request_url, data, function(err, result, res) {
+      // console.log(result);
+      if(res.statusCode == 200){
+          // console.log(result);
+          var json_str = JSON.parse(result.toString());
+          // console.log(json_str);
+          //判断设置使用的协议, 默认使用http
+          if(conf.SCHEME == 'http'){
+              conf.UP_HOST = json_str.http.up[1];
+          }else{
+              conf.UP_HOST = json_str.https.up[0];
+          }
+
+          conf.EXPIRE = 86400 + new Date().getTime();
+          callback();
+          return;
+      }else{
+          var err = new Error('Server responded with status code ' + res.statusCode + ':\n' + res.body.toString());
+          err.statusCode = res.statusCode;
+          err.headers = res.headers;
+          err.body = res.body;
+          throw err;
+          callback();
+      }
+    });
+
+    return;
+
 
 }


### PR DESCRIPTION
ATOM使用qiniu-uploader后发生'unsafe-eval'错误。
https://github.com/knightli/qiniu-uploader/issues/6
https://github.com/knightli/qiniu-uploader/issues/7

```

EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self'".

    at Object.<anonymous> (C:\Users\Jason\.atom\packages\qiniu-uploader\node_modules\sync-request\index.js:10:1)
    at Module._compile (C:\Users\Jason\AppData\Local\atom\app-1.11.2\resources\app.asar\src\native-compile-cache.js:103:30)
    at Object.defineProperty.value [as .js] (C:\Users\Jason\AppData\Local\atom\app-1.11.2\resources\app.asar\src\compile-cache.js:208:21)
```
   

对issue进行排查，发现某些系统的ATOM使用sync-request(或者类似的同步请求）会发生错误。

遂对qiniu模块稍作修改，将sync-request请求改为异步请求。
1. 可以兼容某些系统环境下，atom对sync-request的不兼容
2. 也可以解决sync-request对应用的阻塞引起的用户体验的问题
