### PR TITLE
为什么引入 `package.json` 要用 `fs` 读取 最后再 `JSON.parse` ?

### DIFF
--- a/qiniu/conf.js
+++ b/qiniu/conf.js
@@ -5,7 +5,7 @@ var os = require('os');
 exports.ACCESS_KEY = '<PLEASE APPLY YOUR ACCESS KEY>';
 exports.SECRET_KEY = '<DONT SEND YOUR SECRET KEY TO ANYONE>';
 
-var pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../', 'package.json')));
+var pkg = require('../package.json')
 var ua = function() {
     return 'QiniuNodejs/' + pkg.version + ' (' + os.type() + '; ' + os.platform() + '; ' + os.arch() + '; )';
 }


### PR DESCRIPTION
在我使用 webpack 打包 `qiniu` 放入 electron(render process) 使用的时候发现一个很奇怪的问题.
提示我 找不到 `/package.json`
翻阅到 `conf.js` 发现读取 `package.json` 的用法很诡异...

我觉得应该只是使用 require('../package.json') 读取就好了.

